### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ Building : to build the programs run "make"
 Dependencies : libftdi1 : for sample_grabber
                    http://www.intra2net.com/en/developer/libftdi/download.php
                    libftdi1 has the following dependencies:
-                       libusb1.0
+                       libusb-1.0-0-dev
                        libconfuse
                    We recommend installing these from source from the link.
                FTDI D2XX drivers : for set_uart_mode and set_fifo_mode


### PR DESCRIPTION
Installing libusb-1.0-0-dev was what finally resolved a `not found LIBUSB INSTALL DIR` error when running the cmake part of installing libftdi1-1.1.

Did not seem to need libconfuse...I am not that handy with Linux but `dpkg --get-selections | grep libcon` shows no results.  It's not listed in the libftdi1-1.1 README either.  I'll leave it in there just in case.
