### PR TITLE
Add libusb hacks to kick the kernel driver and reset the device after reconfiguration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
 CC = gcc
-CFLAGS = -Wall -Werror -std=gnu99 -Iinclude
+CFLAGS = -Wall -Werror -std=gnu99 -Iinclude `pkg-config libusb-1.0 --cflags`
+LDLIBS = `pkg-config libusb-1.0 --libs`
 
 all: set_fifo_mode set_uart_mode sample_grabber
 
-set_fifo_mode : set_fifo_mode.c Makefile
-	$(CC) set_fifo_mode.c -o set_fifo_mode -lftd2xx $(CFLAGS)
+set_fifo_mode : set_fifo_mode.c libusb_hacks.c Makefile
+	$(CC) set_fifo_mode.c libusb_hacks.c -o set_fifo_mode -lftd2xx $(CFLAGS) $(LDLIBS)
 
-set_uart_mode : set_uart_mode.c Makefile
-	$(CC) set_uart_mode.c -o set_uart_mode -lftd2xx $(CFLAGS)
+set_uart_mode : set_uart_mode.c libusb_hacks.c Makefile
+	$(CC) set_uart_mode.c libusb_hacks.c -o set_uart_mode -lftd2xx $(CFLAGS) $(LDLIBS)
 
 sample_grabber : sample_grabber.c Makefile
 	$(CC) sample_grabber.c -o sample_grabber pipe/pipe.c -lftdi1 \
-        -pthread -D_FILE_OFFSET_BITS=64 $(CFLAGS)
+        -pthread -D_FILE_OFFSET_BITS=64 $(CFLAGS) $(LDLIBS)
 
 clean:
 	rm -f set_fifo_mode

--- a/libusb_hacks.c
+++ b/libusb_hacks.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ *
+ * Contacts: Gareth McMullin <gareth@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "libusb.h"
+
+void usb_detach_kernel_driver(int vid, int pid)
+{
+  libusb_context *ctx;
+  if (libusb_init(&ctx) != 0)
+    return;
+  libusb_device_handle *dev = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (dev == NULL)
+    return;
+  libusb_detach_kernel_driver(dev, 0);
+  libusb_exit(ctx);
+}
+
+void usb_reset_device(int vid, int pid)
+{
+  libusb_context *ctx;
+  if (libusb_init(&ctx) != 0)
+    return;
+  libusb_device_handle *dev = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (dev == NULL)
+    return;
+  libusb_reset_device(dev);
+  libusb_exit(ctx);
+}
+

--- a/libusb_hacks.h
+++ b/libusb_hacks.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ *
+ * Contacts: Gareth McMullin <gareth@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef __LIBUSB_HACKS_H
+#define __LIBUSB_HACKS_H
+
+void usb_detach_kernel_driver(int vid, int pid);
+void usb_reset_device(int vid, int pid);
+
+#endif
+

--- a/set_fifo_mode.c
+++ b/set_fifo_mode.c
@@ -34,6 +34,7 @@
 #include <getopt.h>
 
 #include "ftd2xx.h"
+#include "libusb_hacks.h"
 
 /* FTDI VID / Piksi custom PID. */
 #define USB_CUSTOM_VID 0x0403
@@ -155,6 +156,7 @@ int main(int argc, char *argv[])
     fprintf(stderr,"ERROR : Failed to set VID and PID, ft_status = %d\n",ft_status);
     return EXIT_FAILURE;
   }
+  usb_detach_kernel_driver(USB_DEFAULT_VID, USB_DEFAULT_PID);
   ft_status = FT_Open(iport, &ft_handle);
   /* Exit program if we haven't opened the device. */
   if (ft_status != FT_OK){
@@ -218,5 +220,6 @@ int main(int argc, char *argv[])
   if (verbose)
     printf("Re-configuring for FIFO mode successful, please unplug and replug your device now.\n");
 
+  usb_reset_device(USB_DEFAULT_VID, USB_DEFAULT_PID);
   return EXIT_SUCCESS;
 }

--- a/set_uart_mode.c
+++ b/set_uart_mode.c
@@ -33,6 +33,7 @@
 #include <getopt.h>
 
 #include "ftd2xx.h"
+#include "libusb_hacks.h"
 
 /* FTDI VID / Piksi custom PID. */
 #define USB_CUSTOM_VID 0x0403
@@ -172,5 +173,8 @@ int main(int argc, char *argv[])
 
   if (verbose)
     printf("Re-configuring for UART mode successful, please unplug and replug your device now\n");
+
+  usb_reset_device(USB_CUSTOM_VID, USB_CUSTOM_PID);
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- Tested and working on Linux.
- May or may not work on OS X, but probably hasn't made anything worse.
- Adds a build dependency on libusb1.